### PR TITLE
Adjust index calculation for halo and time step, add CL usage

### DIFF
--- a/examples/dam_break.cpp
+++ b/examples/dam_break.cpp
@@ -122,6 +122,22 @@ int main( int argc, char* argv[] )
 
     Kokkos::initialize( argc, argv );
 
+    // check inputs and write usage
+    if (argc < 8) {
+        std::cerr << "Usage: ./DamBreak cell_size parts_per_cell_size halo_cells dt t_end write_freq device\n";
+        std::cerr << "\nwhere cell_size       edge length of a computational cell (domain is unit cube)\n";
+        std::cerr << "      parts_per_cell  particles per cell in each direction\n";
+        std::cerr << "      halo_cells      number of halo cells\n";
+        std::cerr << "      dt              time step size\n";
+        std::cerr << "      t_end           simulation end time\n";
+        std::cerr << "      write_freq      number of steps between output files\n";
+        std::cerr << "      device          compute device: serial, openmp, cuda, hip\n";
+        std::cerr << "\nfor example: ./DamBreak 0.05 2 0 0.001 1.0 10 serial\n";
+        Kokkos::finalize();
+        MPI_Finalize();
+        return 0;
+    }
+
     // cell size
     double cell_size = std::atof( argv[1] );
 

--- a/examples/dam_break.cpp
+++ b/examples/dam_break.cpp
@@ -69,24 +69,23 @@ void damBreak( const double cell_size, const int ppc, const int halo_size,
                const std::string& device )
 {
     // The dam break domain is in a box on [0,1] in each dimension.
-    Kokkos::Array<double, 6> global_box = { 0.0, 0.0, 0.0, 1.0, 1.0, 1.0 };
+    Kokkos::Array<double, 6> global_box = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
 
     // Compute the number of cells in each direction. The user input must
     // squarely divide the domain.
-    std::array<int, 3> global_num_cell = {
-        static_cast<int>( 1.0 / cell_size ),
-        static_cast<int>( 1.0 / cell_size ),
-        static_cast<int>( 1.0 / cell_size ) };
+    std::array<int, 3> global_num_cell = {static_cast<int>( 1.0 / cell_size ),
+                                          static_cast<int>( 1.0 / cell_size ),
+                                          static_cast<int>( 1.0 / cell_size )};
 
     // This will look like a 2D problem so make the Y direction periodic.
-    std::array<bool, 3> periodic = { false, false, false };
+    std::array<bool, 3> periodic = {false, false, false};
 
     // Due to the 2D nature of the problem we will only partition in Y. The
     // behavior of the fluid will be to largely just run out in X and Z with
     // little movement in Y.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 1, comm_size, 1 };
+    std::array<int, 3> ranks_per_dim = {1, comm_size, 1};
     Cajita::ManualPartitioner partitioner( ranks_per_dim );
 
     // Material properties.
@@ -123,15 +122,21 @@ int main( int argc, char* argv[] )
     Kokkos::initialize( argc, argv );
 
     // check inputs and write usage
-    if (argc < 8) {
-        std::cerr << "Usage: ./DamBreak cell_size parts_per_cell_size halo_cells dt t_end write_freq device\n";
-        std::cerr << "\nwhere cell_size       edge length of a computational cell (domain is unit cube)\n";
-        std::cerr << "      parts_per_cell  particles per cell in each direction\n";
+    if ( argc < 8 )
+    {
+        std::cerr << "Usage: ./DamBreak cell_size parts_per_cell_size "
+                     "halo_cells dt t_end write_freq device\n";
+        std::cerr << "\nwhere cell_size       edge length of a computational "
+                     "cell (domain is unit cube)\n";
+        std::cerr
+            << "      parts_per_cell  particles per cell in each direction\n";
         std::cerr << "      halo_cells      number of halo cells\n";
         std::cerr << "      dt              time step size\n";
         std::cerr << "      t_end           simulation end time\n";
-        std::cerr << "      write_freq      number of steps between output files\n";
-        std::cerr << "      device          compute device: serial, openmp, cuda, hip\n";
+        std::cerr
+            << "      write_freq      number of steps between output files\n";
+        std::cerr << "      device          compute device: serial, openmp, "
+                     "cuda, hip\n";
         std::cerr << "\nfor example: ./DamBreak 0.05 2 0 0.001 1.0 10 serial\n";
         Kokkos::finalize();
         MPI_Finalize();

--- a/examples/dam_break.cpp
+++ b/examples/dam_break.cpp
@@ -22,7 +22,7 @@ struct ParticleInitFunc
 
     ParticleInitFunc( const double cell_size, const int ppc,
                       const double density )
-        : _volume( cell_size * cell_size * cell_size / ppc )
+        : _volume( cell_size * cell_size * cell_size / ( ppc * ppc * ppc ) )
         , _mass( _volume * density )
     {
     }
@@ -31,7 +31,7 @@ struct ParticleInitFunc
     KOKKOS_INLINE_FUNCTION bool operator()( const double x[3],
                                             ParticleType& p ) const
     {
-        if ( 0.0 <= x[0] && x[0] <= 0.4 && 0.0 <= x[1] && x[1] <= 0.4 &&
+        if ( 0.0 <= x[0] && x[0] <= 0.4 && 0.0 <= x[1] && x[1] <= 1.0 &&
              0.0 <= x[2] && x[2] <= 0.6 )
         {
             // Affine matrix.

--- a/examples/dam_break.cpp
+++ b/examples/dam_break.cpp
@@ -69,23 +69,24 @@ void damBreak( const double cell_size, const int ppc, const int halo_size,
                const std::string& device )
 {
     // The dam break domain is in a box on [0,1] in each dimension.
-    Kokkos::Array<double, 6> global_box = {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
+    Kokkos::Array<double, 6> global_box = { 0.0, 0.0, 0.0, 1.0, 1.0, 1.0 };
 
     // Compute the number of cells in each direction. The user input must
     // squarely divide the domain.
-    std::array<int, 3> global_num_cell = {static_cast<int>( 1.0 / cell_size ),
-                                          static_cast<int>( 1.0 / cell_size ),
-                                          static_cast<int>( 1.0 / cell_size )};
+    std::array<int, 3> global_num_cell = {
+        static_cast<int>( 1.0 / cell_size ),
+        static_cast<int>( 1.0 / cell_size ),
+        static_cast<int>( 1.0 / cell_size ) };
 
     // This will look like a 2D problem so make the Y direction periodic.
-    std::array<bool, 3> periodic = {false, false, false};
+    std::array<bool, 3> periodic = { false, false, false };
 
     // Due to the 2D nature of the problem we will only partition in Y. The
     // behavior of the fluid will be to largely just run out in X and Z with
     // little movement in Y.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {1, comm_size, 1};
+    std::array<int, 3> ranks_per_dim = { 1, comm_size, 1 };
     Cajita::ManualPartitioner partitioner( ranks_per_dim );
 
     // Material properties.

--- a/examples/dam_break.cpp
+++ b/examples/dam_break.cpp
@@ -98,7 +98,7 @@ void damBreak( const double cell_size, const int ppc, const int halo_size,
     // Gravity pulls down in z.
     double gravity = 9.81;
 
-    // Free slip conditions in X and Z.
+    // Free slip conditions (alternative: NO_SLIP)
     ExaMPM::BoundaryCondition bc;
     bc.boundary[0] = ExaMPM::BoundaryType::FREE_SLIP;
     bc.boundary[1] = ExaMPM::BoundaryType::FREE_SLIP;

--- a/examples/free_fall.cpp
+++ b/examples/free_fall.cpp
@@ -68,22 +68,21 @@ void freeFall( const double cell_size, const int ppc, const int halo_size,
                const std::string& device )
 {
     // The free fall domain is in a box on [-0.5,0.5] in each dimension.
-    Kokkos::Array<double, 6> global_box = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 };
+    Kokkos::Array<double, 6> global_box = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5};
 
     // Compute the number of cells in each direction. The user input must
     // squarely divide the domain.
-    std::array<int, 3> global_num_cell = {
-        static_cast<int>( 1.0 / cell_size ),
-        static_cast<int>( 1.0 / cell_size ),
-        static_cast<int>( 1.0 / cell_size ) };
+    std::array<int, 3> global_num_cell = {static_cast<int>( 1.0 / cell_size ),
+                                          static_cast<int>( 1.0 / cell_size ),
+                                          static_cast<int>( 1.0 / cell_size )};
 
     // All boundaries are periodic to allow the ball to keep falling.
-    std::array<bool, 3> periodic = { true, true, true };
+    std::array<bool, 3> periodic = {true, true, true};
 
     // For simplicity we will only partition in Y.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = { 1, comm_size, 1 };
+    std::array<int, 3> ranks_per_dim = {1, comm_size, 1};
     Cajita::ManualPartitioner partitioner( ranks_per_dim );
 
     // Material properties.
@@ -120,15 +119,21 @@ int main( int argc, char* argv[] )
     Kokkos::initialize( argc, argv );
 
     // check inputs and write usage
-    if (argc < 8) {
-        std::cerr << "Usage: ./FreeFall cell_size parts_per_cell_size halo_cells dt t_end write_freq device\n";
-        std::cerr << "\nwhere cell_size       edge length of a computational cell (domain is unit cube)\n";
-        std::cerr << "      parts_per_cell  particles per cell in each direction\n";
+    if ( argc < 8 )
+    {
+        std::cerr << "Usage: ./FreeFall cell_size parts_per_cell_size "
+                     "halo_cells dt t_end write_freq device\n";
+        std::cerr << "\nwhere cell_size       edge length of a computational "
+                     "cell (domain is unit cube)\n";
+        std::cerr
+            << "      parts_per_cell  particles per cell in each direction\n";
         std::cerr << "      halo_cells      number of halo cells\n";
         std::cerr << "      dt              time step size\n";
         std::cerr << "      t_end           simulation end time\n";
-        std::cerr << "      write_freq      number of steps between output files\n";
-        std::cerr << "      device          compute device: serial, openmp, cuda, hip\n";
+        std::cerr
+            << "      write_freq      number of steps between output files\n";
+        std::cerr << "      device          compute device: serial, openmp, "
+                     "cuda, hip\n";
         std::cerr << "\nfor example: ./FreeFall 0.05 2 0 0.001 1.0 10 serial\n";
         Kokkos::finalize();
         MPI_Finalize();

--- a/examples/free_fall.cpp
+++ b/examples/free_fall.cpp
@@ -68,21 +68,22 @@ void freeFall( const double cell_size, const int ppc, const int halo_size,
                const std::string& device )
 {
     // The free fall domain is in a box on [-0.5,0.5] in each dimension.
-    Kokkos::Array<double, 6> global_box = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5};
+    Kokkos::Array<double, 6> global_box = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 };
 
     // Compute the number of cells in each direction. The user input must
     // squarely divide the domain.
-    std::array<int, 3> global_num_cell = {static_cast<int>( 1.0 / cell_size ),
-                                          static_cast<int>( 1.0 / cell_size ),
-                                          static_cast<int>( 1.0 / cell_size )};
+    std::array<int, 3> global_num_cell = {
+        static_cast<int>( 1.0 / cell_size ),
+        static_cast<int>( 1.0 / cell_size ),
+        static_cast<int>( 1.0 / cell_size ) };
 
     // All boundaries are periodic to allow the ball to keep falling.
-    std::array<bool, 3> periodic = {true, true, true};
+    std::array<bool, 3> periodic = { true, true, true };
 
     // For simplicity we will only partition in Y.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
-    std::array<int, 3> ranks_per_dim = {1, comm_size, 1};
+    std::array<int, 3> ranks_per_dim = { 1, comm_size, 1 };
     Cajita::ManualPartitioner partitioner( ranks_per_dim );
 
     // Material properties.

--- a/examples/free_fall.cpp
+++ b/examples/free_fall.cpp
@@ -67,7 +67,7 @@ void freeFall( const double cell_size, const int ppc, const int halo_size,
                const double delta_t, const double t_final, const int write_freq,
                const std::string& device )
 {
-    // The dam break domain is in a box on [0,1] in each dimension.
+    // The free fall domain is in a box on [-0.5,0.5] in each dimension.
     Kokkos::Array<double, 6> global_box = { -0.5, -0.5, -0.5, 0.5, 0.5, 0.5 };
 
     // Compute the number of cells in each direction. The user input must
@@ -77,12 +77,10 @@ void freeFall( const double cell_size, const int ppc, const int halo_size,
         static_cast<int>( 1.0 / cell_size ),
         static_cast<int>( 1.0 / cell_size ) };
 
-    // This will look like a 2D problem so make the Y direction periodic.
+    // All boundaries are periodic to allow the ball to keep falling.
     std::array<bool, 3> periodic = { true, true, true };
 
-    // Due to the 2D nature of the problem we will only partition in Y. The
-    // behavior of the fluid will be to largely just run out in X and Z with
-    // little movement in Y.
+    // For simplicity we will only partition in Y.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );
     std::array<int, 3> ranks_per_dim = { 1, comm_size, 1 };

--- a/examples/free_fall.cpp
+++ b/examples/free_fall.cpp
@@ -121,6 +121,22 @@ int main( int argc, char* argv[] )
 
     Kokkos::initialize( argc, argv );
 
+    // check inputs and write usage
+    if (argc < 8) {
+        std::cerr << "Usage: ./FreeFall cell_size parts_per_cell_size halo_cells dt t_end write_freq device\n";
+        std::cerr << "\nwhere cell_size       edge length of a computational cell (domain is unit cube)\n";
+        std::cerr << "      parts_per_cell  particles per cell in each direction\n";
+        std::cerr << "      halo_cells      number of halo cells\n";
+        std::cerr << "      dt              time step size\n";
+        std::cerr << "      t_end           simulation end time\n";
+        std::cerr << "      write_freq      number of steps between output files\n";
+        std::cerr << "      device          compute device: serial, openmp, cuda, hip\n";
+        std::cerr << "\nfor example: ./FreeFall 0.05 2 0 0.001 1.0 10 serial\n";
+        Kokkos::finalize();
+        MPI_Finalize();
+        return 0;
+    }
+
     // cell size
     double cell_size = std::atof( argv[1] );
 

--- a/src/ExaMPM_BoundaryConditions.hpp
+++ b/src/ExaMPM_BoundaryConditions.hpp
@@ -80,7 +80,7 @@ struct BoundaryCondition
         }
 
         // High x
-        if ( gi >= max[0] - 1 )
+        if ( gi >= max[0] )
         {
             if ( boundary[3] == BoundaryType::NO_SLIP )
             {
@@ -95,7 +95,7 @@ struct BoundaryCondition
         }
 
         // High y
-        if ( gj >= max[1] - 1 )
+        if ( gj >= max[1] )
         {
             if ( boundary[4] == BoundaryType::NO_SLIP )
             {
@@ -110,7 +110,7 @@ struct BoundaryCondition
         }
 
         // High z
-        if ( gk >= max[2] - 1 )
+        if ( gk >= max[2] )
         {
             if ( boundary[5] == BoundaryType::NO_SLIP )
             {

--- a/src/ExaMPM_Mesh.hpp
+++ b/src/ExaMPM_Mesh.hpp
@@ -73,7 +73,7 @@ class Mesh
         for ( int d = 0; d < 3; ++d )
         {
             _min_domain_global_node_index[d] = 0;
-            _max_domain_global_node_index[d] = num_cell[d] + 1;
+            _max_domain_global_node_index[d] = num_cell[d];
         }
 
         // For dimensions that are not periodic we pad by the minimum halo
@@ -86,7 +86,7 @@ class Mesh
                 global_high_corner[d] += cell_size * minimum_halo_cell_width;
                 num_cell[d] += 2 * minimum_halo_cell_width;
                 _min_domain_global_node_index[d] += minimum_halo_cell_width;
-                _max_domain_global_node_index[d] -= minimum_halo_cell_width;
+                _max_domain_global_node_index[d] += minimum_halo_cell_width;
             }
         }
 

--- a/src/ExaMPM_Solver.hpp
+++ b/src/ExaMPM_Solver.hpp
@@ -85,14 +85,14 @@ class Solver : public SolverBase
         for ( int t = 0; t < num_step; ++t )
         {
             if ( 0 == _rank && 0 == t % write_freq )
-                printf( "Step %d / %d\n", t + 1, num_step );
+                printf( "Step %d / %d\n", t, num_step );
 
             TimeIntegrator::step( ExecutionSpace(), *_pm, delta_t, _gravity,
                                   _bc );
 
             _pm->communicateParticles( _halo_min );
 
-            if ( 0 == t % write_freq )
+            if ( 0 == ( t + 1 ) % write_freq )
 #ifdef Cabana_ENABLE_SILO
                 Cajita::Experimental::SiloParticleOutput::writeTimeStep(
                     "particles", _mesh->localGrid()->globalGrid(), t + 1, time,


### PR DESCRIPTION
Here are a set of bug fixes, usability improvements, and comment corrections. I wasn't sure whether these should be packaged into multiple PRs or one for simplicity.

The bugs were in calculating the range of indices for the non-halo domain and the application of the BCs vs. cell index. Before, the DamBreak sim would show frozen particles in the range 0.94 < y < 1 (for dx=0.01 and 3 halo cells) and asymmetry in the y axis.

Additionally, the codes would write output at steps 0, 1, 101, ... when setting100 steps between output. Now it writes output at 0, 100, 200, etc.