### PR TITLE
`particleGridMigrate` -> `particleMigrate` (Update to latest Cabana)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,19 +45,20 @@ jobs:
         uses: actions/checkout@v2.2.0
         with:
           repository: kokkos/kokkos
-          ref: 3.7.02
+          ref: 4.1.00
           path: kokkos
       - name: Build kokkos
         working-directory: kokkos
         run: |
-          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_CXX_STANDARD=14 -DKokkos_ENABLE_${{ matrix.backend }}=ON
+          cmake -B build -DCMAKE_INSTALL_PREFIX=$HOME/kokkos -DKokkos_ENABLE_${{ matrix.backend }}=ON
           cmake --build build --parallel 2
           cmake --install build
       - name: Checkout Cabana
         uses: actions/checkout@v2.2.0
         with:
           repository: ECP-copa/Cabana
-          ref: 0.6.1
+          # Post 0.7.0
+          ref: facdb9097b68b733626911d1935a946f467cf143
           path: Cabana
       - name: Build Cabana
         working-directory: Cabana

--- a/src/ExaMPM_ProblemManager.hpp
+++ b/src/ExaMPM_ProblemManager.hpp
@@ -272,8 +272,8 @@ class ProblemManager
     void communicateParticles( const int minimum_halo_width )
     {
         auto positions = get( Location::Particle(), Field::Position() );
-        Cabana::Grid::particleGridMigrate( *( _mesh->localGrid() ), positions,
-                                           _particles, minimum_halo_width );
+        Cabana::Grid::particleMigrate( *( _mesh->localGrid() ), positions,
+                                       _particles, minimum_halo_width );
     }
 
   private:


### PR DESCRIPTION
Currently, the build fails due to a function mismatch: `Cabana::Grid::particleGridMigrate`. 
This is updated to: `Cabana::Grid::particleMigrate`.

Fixes #60 