### PR TITLE
CI: run on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
             backend: 'SERIAL'
             cmake_build_type: 'Debug'
             output: 'BOTH'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/ecp-copa/ci-containers/${{ matrix.distro }}
     steps:

--- a/.github/workflows/Weekly.yml
+++ b/.github/workflows/Weekly.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         backend: ["OPENMP", "SERIAL"]
         kokkos_ver: ["develop"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: ghcr.io/ecp-copa/ci-containers/ubuntu:latest
     steps:
       - name: Checkout kokkos


### PR DESCRIPTION
20.04 is being retired; avoid having to do this in the future with latest
